### PR TITLE
Get graph working with poller on report page; fix #2

### DIFF
--- a/interface/urls.py
+++ b/interface/urls.py
@@ -26,7 +26,7 @@ urlpatterns = patterns('',
     url(r'^report/(?:(?P<task_id>\d+)/)?$', 'interface.views.report', name='report'),
     url(r'^reports/$', 'interface.views.reports', name='reports'),
 
-    url(r'^json_tree_graph/<?:(?P<analysis_id>[\w]+)/)?$', 'interface.views.json_tree_graph', name='json_tree_graph'),
+    url(r'^json_tree_graph/(?:(?P<analysis_id>[\w]+)/)?$', 'interface.views.json_tree_graph', name='json_tree_graph'),
 
     url(r'^content/(?:(?P<content_id>[\w]+)/)?$', 'interface.views.content', name='content'),
 

--- a/interface/urls.py
+++ b/interface/urls.py
@@ -26,7 +26,7 @@ urlpatterns = patterns('',
     url(r'^report/(?:(?P<task_id>\d+)/)?$', 'interface.views.report', name='report'),
     url(r'^reports/$', 'interface.views.reports', name='reports'),
 
-    url(r'^json_tree_graph/(?P<analysis_id>[\w]+)/$', 'interface.views.json_tree_graph', name='json_tree_graph'),
+    url(r'^json_tree_graph/<?:(?P<analysis_id>[\w]+)/)?$', 'interface.views.json_tree_graph', name='json_tree_graph'),
 
     url(r'^content/(?:(?P<content_id>[\w]+)/)?$', 'interface.views.content', name='content'),
 

--- a/interface/views.py
+++ b/interface/views.py
@@ -102,9 +102,12 @@ def report(request, task_id):
     return render(request, 'interface/result.html', context)
 
 @login_required
-def json_tree_graph(request, analysis_id):
+def json_tree_graph(request, analysis_id=None):
     # TODO: migrate this view to the APIs? (Not sure if it's easily feasible)
     # TODO: use NetworkX to construct the graph?
+    if not analysis_id:
+        raise Http404("Analyis not found");
+
     graph = {
         'analysis_id': analysis_id,
         'graph': {

--- a/templates/interface/result.html
+++ b/templates/interface/result.html
@@ -274,6 +274,9 @@
 {% block bottomscripts %}
 // Declare vars
 var status = {{ task.status }};
+var object_id = '{{ task.object_id }}';
+var json_tree_graph_url = '{% url 'interface:json_tree_graph' 'tmp' %}'.slice(0, -4);
+
 var selected_node = null;
 var poller = false;
 
@@ -312,7 +315,7 @@ function display_graph(){
       .append("g")
         .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
     
-    d3.json("{% url 'interface:json_tree_graph' task.object_id %}", function(error, flare) {
+    d3.json(json_tree_graph_url + object_id, function(error, flare) {
         root = flare.graph.nodes;
         root.x0 = height / 2;
         root.y0 = 0;
@@ -478,6 +481,9 @@ function display_content_panel(){
 function check_status(){
     if(status < 2){
         $.getJSON( "{% url 'api_dispatch_detail' api_name="v1" resource_name="task" pk=task.id %}", function( task ) {
+	    if (object_id != task['object_id']) {
+	        object_id = task['object_id'];
+	    }
             if (status != task['status']){
                 status = task['status']
                 if (status == 0){

--- a/templates/interface/result.html
+++ b/templates/interface/result.html
@@ -275,7 +275,7 @@
 // Declare vars
 var status = {{ task.status }};
 var object_id = '{{ task.object_id }}';
-var json_tree_graph_url = '{% url 'interface:json_tree_graph' 'tmp' %}'.slice(0, -4);
+var json_tree_graph_url = '{% url 'interface:json_tree_graph' %}';
 
 var selected_node = null;
 var poller = false;

--- a/templates/interface/result.html
+++ b/templates/interface/result.html
@@ -275,7 +275,6 @@
 // Declare vars
 var status = {{ task.status }};
 var object_id = '{{ task.object_id }}';
-var json_tree_graph_url = '{% url 'interface:json_tree_graph' %}';
 
 var selected_node = null;
 var poller = false;
@@ -315,7 +314,7 @@ function display_graph(){
       .append("g")
         .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
     
-    d3.json(json_tree_graph_url + object_id, function(error, flare) {
+    d3.json('{% url 'interface:json_tree_graph' %}' + object_id, function(error, flare) {
         root = flare.graph.nodes;
         root.x0 = height / 2;
         root.y0 = 0;


### PR DESCRIPTION
Because the API call in `check_status()` returns the whole task, any item in the task can be updated from it.  This pull request adds a check seeing if `task.object_id` changes, and updates it if it does change.

The error that was being thrown - found in #2 - is also fixed because the interface `json_tree_graph` isn't being called with an empty `task.object_id` when the page is rendered.

`slice(0, -4)` on line 278 removes the last 4 chars from the string, which in this case is 'tmp/', leaving '/json_tree_graph/'... I can add a comment noting that if it's needed.
