### PR TITLE
TaskAdmin Changes

### DIFF
--- a/interface/admin.py
+++ b/interface/admin.py
@@ -35,7 +35,7 @@ remove_broken_url.short_description = 'Remove Broken Url tag'
 
 def enable_javaplugin(modelAdmin, request, queryset):
     queryset.update(no_javaplugin = True)
-add_broken_url.short_description = 'Enable Java Plugins'
+enable_javaplugin.short_description = 'Enable Java Plugins'
 
 def disable_javaplugin(modelAdmin, request, queryset):
     queryset.update(no_javaplugin = False)

--- a/interface/admin.py
+++ b/interface/admin.py
@@ -25,28 +25,27 @@ from .models import Proxy, Task
 
 # Register your models here.
 
-def add_broken_url(modelAdmin, request, queryset):
-    queryset.update(broken_url = True)
-add_broken_url.short_description = 'Add Broken Url tag'
-
-def remove_broken_url(modelAdmin, request, queryset):
-    queryset.update(broken_url = False)
-remove_broken_url.short_description = 'Remove Broken Url tag'
-
-def enable_javaplugin(modelAdmin, request, queryset):
-    queryset.update(no_javaplugin = True)
-enable_javaplugin.short_description = 'Enable Java Plugins'
-
-def disable_javaplugin(modelAdmin, request, queryset):
-    queryset.update(no_javaplugin = False)
-disable_javaplugin.short_description = 'Disable Java Plugins'
-
 class TaskAdmin(admin.ModelAdmin):
     #list_display = ['__unicode__', 'proxy', 'broken_url']
     list_display = ['proxy', 'broken_url', 'no_javaplugin']
     date_hierarchy = 'submitted_on'
-    actions = [add_broken_url, remove_broken_url, 
-        enable_javaplugin, disable_javaplugin]
+    actions = ['add_broken_url', 'remove_broken_url',
+        'enable_javaplugin', 'disable_javaplugin']
+    def add_broken_url(self, request, queryset):
+        queryset.update(broken_url = True)
+    add_broken_url.short_description = 'Add Broken Url tag'
+
+    def remove_broken_url(self, request, queryset):
+        queryset.update(broken_url = False)
+    remove_broken_url.short_description = 'Remove Broken Url tag'
+
+    def enable_javaplugin(self, request, queryset):
+        queryset.update(no_javaplugin = True)
+    enable_javaplugin.short_description = 'Enable Java Plugins'
+
+    def disable_javaplugin(self, request, queryset):
+        queryset.update(no_javaplugin = False)
+    disable_javaplugin.short_description = 'Disable Java Plugins'
 
 admin.site.register(Proxy)
 admin.site.register(Task, TaskAdmin)

--- a/interface/admin.py
+++ b/interface/admin.py
@@ -30,7 +30,9 @@ class TaskAdmin(admin.ModelAdmin):
     list_display = ['proxy', 'broken_url', 'no_javaplugin']
     date_hierarchy = 'submitted_on'
     actions = ['add_broken_url', 'remove_broken_url',
-        'enable_javaplugin', 'disable_javaplugin']
+        'enable_javaplugin', 'disable_javaplugin',
+        'sharingmodel_groups', 'sharingmodel_private',
+        'sharingmodel_public']
     def add_broken_url(self, request, queryset):
         queryset.update(broken_url = True)
     add_broken_url.short_description = 'Add Broken Url tag'
@@ -46,6 +48,18 @@ class TaskAdmin(admin.ModelAdmin):
     def disable_javaplugin(self, request, queryset):
         queryset.update(no_javaplugin = False)
     disable_javaplugin.short_description = 'Disable Java Plugins'
+
+    def sharingmodel_groups(self, request, queryset):
+        queryset.update(sharing_model = 2)
+    sharingmodel_groups.short_description = 'Share with Groups'
+
+    def sharingmodel_private(self, request, queryset):
+        queryset.update(sharing_model = 1)
+    sharingmodel_private.short_description = 'Make Private'
+
+    def sharingmodel_public(self, request, queryset):
+        queryset.update(sharing_model = 0)
+    sharingmodel_public.short_description = 'Make Public'
 
 admin.site.register(Proxy)
 admin.site.register(Task, TaskAdmin)


### PR DESCRIPTION
1. Fixed error in short descriptions under enable_javaplugin function.
2. Changes functions to method as recommended in docs https://docs.djangoproject.com/en/1.7/ref/contrib/admin/actions/ (as they are coupled with Task Model only)
3. Added Admin actions to make multiple tasks public, private or shared with groups.
