### PR TITLE
Make New Task template responsive

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -56,7 +56,7 @@ img.fade:hover {
 
         <footer class="footer">
             <div class="row">
-                <div class="col-md-1 col-md-offset-11"><a href="#">Back to top</a></div>
+                <div class="col-md-2 col-sm-2 col-xs-4"><a href="#">Back to top</a></div>
             </div>
         </footer>
     </div>

--- a/templates/interface/new_task.html
+++ b/templates/interface/new_task.html
@@ -6,7 +6,7 @@
 <form method="post">
     {% csrf_token %}
     <div class="row">
-        <div class="col-md-10">
+        <div class="col-md-10 col-sm-9 col-xs-12">
             <!-- Display any form errors -->
             {% if form.errors %}
             <div class="alert alert-danger" role="alert">Please review the errors below and try again</div>
@@ -311,7 +311,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-2 col-sm-3 hidden-xs">
             <nav class="bs-docs-sidebar">
                 <ul id="sidebar" class="nav nav-stacked fixed">
                     <li><input type="submit" id="rule_save" class="btn btn-danger" value="Run" style="margin-bottom:20px;margin-left:20px;"></li>
@@ -323,6 +323,9 @@
                 </ul>
             </nav>
         </div>
+	<div class="col-xs-12 visible-xs">
+		<input type="submit" id="rule_save" class="btn btn-danger" value="Run" style="margin-left:20px;">
+	</div>
     </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
The New Task page on small and extra-small screens doesn't display the navbar or the run button properly because the navbar is fixed.  To fix this I added Bootstrap classes that designate the column widths of the task column and navbar column for small screens.  

I also added a run button to the bottom of the page on extra-small screens and added the `hidden-xs` class to the navbar, which hides it on extra-small screens. 

I did the same to the "Back to top" link in the footer - it also wasn't displaying properly on small or extra-small screens.
