### PR TITLE
Issue #12 Node highlighting in tree graph

### DIFF
--- a/templates/static/js/real_setTree.js
+++ b/templates/static/js/real_setTree.js
@@ -114,12 +114,17 @@ function setTree() {
             .attr("transform", function(d) {
                 return "translate(" + source.y0 + "," + source.x0 + ")";
             })
-            .on("click", click)
-            .on("dblclick", dblclick);
+            .on("dblclick", dblclick)
+            .on("click", click);
         nodeEnter.append("circle")
-            .attr("r", 1e-6)
-            .style("fill", function(d) {
-                return d._children ? "lightsteelblue" : "#fff";
+            .attr({"r": 1e-6,"current":"false"})
+            .style("stroke", function(d) {
+                return d._children ? "#BA00FF" : "steelblue";
+            }).on("click",function(){
+                if(d3.select('[current=true]')[0][0]){
+                    d3.select('[current=true]').style('stroke','steelblue').attr('current','false');
+                }
+                d3.select(this).style("stroke","#ff5722").attr('current','true');
             });
         nodeEnter.append("text")
             .attr("x", function(d) {
@@ -141,8 +146,8 @@ function setTree() {
             });
         nodeUpdate.select("circle")
             .attr("r", 4.5)
-            .style("fill", function(d) {
-                return d._children ? "lightsteelblue" : "#fff";
+            .style("stroke", function(d) {
+                return d._children ? "#BA00FF" : "steelblue";
             });
         nodeUpdate.select("text")
             .style("fill-opacity", 1);
@@ -204,11 +209,11 @@ function setTree() {
         });
     }
     /* Toggle children on click.*/
-    function dblclick(d) {
+    function click(d) {
         setPanels(d.nid);
     }
 
-    function click(d) {
+    function dblclick(d) {
         if ($.inArray(d, threat_path_elements) === -1) {
             if (d.children) {
                 d._children = d.children;

--- a/templates/static/js/real_setTree.js
+++ b/templates/static/js/real_setTree.js
@@ -122,7 +122,9 @@ function setTree() {
                 return d._children ? "#BA00FF" : "steelblue";
             }).on("click",function(){
                 if(d3.select('[current=true]')[0][0]){
-                    d3.select('[current=true]').style('stroke','steelblue').attr('current','false');
+                    d3.select('[current=true]').style("stroke", function(d) {
+                        return d._children ? "#BA00FF" : "steelblue";
+                    }).attr('current','false');
                 }
                 d3.select(this).style("stroke","#ff5722").attr('current','true');
             });


### PR DESCRIPTION
I have added a different highlighting that was missing initially for cases: Currently selected node, Expandable nodes using a different stroke color for all the different cases. The color changes now are:
Selected Node: rgb(255, 87, 34)
Collapsed Node: rgb(186, 0, 255)
Expanded Node: rgb(70, 130, 180)
