### PR TITLE
User credentials for authentication on rabbitmq server

### DIFF
--- a/conf/backend.conf
+++ b/conf/backend.conf
@@ -1,5 +1,5 @@
 [backend]
 host = localhost
-api_key = testkey
-api_user = testuser
+rabbit_user = admin
+rabbit_password = admin
 BE = 192.168.58.132

--- a/interface/producer.py
+++ b/interface/producer.py
@@ -112,9 +112,3 @@ class Producer(Thread):
             self.thread_exception = pika.exceptions.ProbableAccessDeniedError
 
 
-if __name__ == '__main__':
-    test = Producer("message", '192.168.58.129', 5672, 'rpc_queue', 1)
-    test.start()
-    time.sleep(4)
-    print test.thread_exception
-


### PR DESCRIPTION
config file with rabbit_user and rabbit_password used to authenticate user on the backend rabbitmq server while trying to send a message. Docker version start script deals with creating user ans giving permission 
